### PR TITLE
Add custom wordpress endpoint types

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 import type { HTMLElement } from "node-html-parser";
+import type { ParsedBlock } from "@wordpress/block-serialization-default-parser";
 import { parse } from "node-html-parser";
 import he from "he";
 
@@ -33,6 +34,65 @@ export type WordPressArticle = {
   _links: {
     "wp:featuredmedia": WordPressFeaturedMedia[];
   };
+};
+
+export type ImageSource = {
+  uri: string;
+  width: number;
+  height: number;
+};
+
+export type ImageData = {
+  id: number;
+  sources: ImageSource[];
+  caption: string;
+  alt: string;
+  position: string; // TODO: from mobile app: clarify possible string values
+};
+
+export type AudioData = { url: string; caption: string };
+
+export type VideoData = {
+  url: string;
+  caption: string;
+  aspectRatio: number;
+};
+
+export type Block = Omit<ParsedBlock, "innerBlocks"> & {
+  innerBlocks: Block[];
+  innerContent: string[];
+  index: number;
+} & (
+    | { blockName: "core/audio"; data: AudioData | null }
+    | { blockName: "core/video"; data: VideoData | null }
+    | { blockName: "core/image"; data: ImageData | null }
+    | { blockName: "jetpack/image-compare"; data: ImageData[] | null }
+    | { blockName: "jetpack/slideshow"; data: ImageData[] | null }
+    | { blockName: "newspack-blocks/homepage-articles"; data: Article[] | null }
+    | { blockName: string; data: null }
+  );
+
+export type Author = {
+  display_name: string;
+  user_nicename: string;
+};
+
+export type Article = {
+  id: string;
+  permalink: string;
+  category: {
+    parent: string | null;
+    primary: string | null;
+  };
+  title: string;
+  date: string;
+  excerpt: string | null;
+  content: Block[] | null;
+  authors: Author[];
+  image: ImageData | null;
+  estimatedTime: number | null;
+  redirection: string | null;
+  relatedPosts: Article[] | null;
 };
 
 function trim(caption: string): string {

--- a/index.ts
+++ b/index.ts
@@ -60,7 +60,6 @@ export type VideoData = {
 
 export type Block = Omit<ParsedBlock, "innerBlocks"> & {
   innerBlocks: Block[];
-  innerContent: string[];
   index: number;
 } & (
     | { blockName: "core/audio"; data: AudioData | null }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
+    "@wordpress/block-serialization-default-parser": "^4.55.0",
     "he": "^1.2.0",
     "node-html-parser": "^6.1.10"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@wordpress/block-serialization-default-parser':
+    specifier: ^4.55.0
+    version: 4.55.0
   he:
     specifier: ^1.2.0
     version: 1.2.0
@@ -22,9 +25,23 @@ devDependencies:
 
 packages:
 
+  /@babel/runtime@7.24.4:
+    resolution: {integrity: sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.1
+    dev: false
+
   /@types/he@1.2.2:
     resolution: {integrity: sha512-v2gT1gRK65k9nz8SVSXo3lh7AHnRPL3mRcYNhhsqL/L2S1xt/MGyEI5a7vJPXWik/IxTtAktXf8/HlCxDR1nsw==}
     dev: true
+
+  /@wordpress/block-serialization-default-parser@4.55.0:
+    resolution: {integrity: sha512-5CbUjxpt4YpCFHPwh4whJvt054wK+yYvhcxcKUPIF5Qa+pQF8BvaXy5ufEQ5C4FZiRlyJTRUKeDfUORzdLZmjQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@babel/runtime': 7.24.4
+    dev: false
 
   /boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -93,6 +110,10 @@ packages:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
     dependencies:
       boolbase: 1.0.0
+    dev: false
+
+  /regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
     dev: false
 
   /typescript@5.2.2:


### PR DESCRIPTION
- Addresses https://github.com/michigandaily/alt-text-tracker/issues/16

These types are mostly based on the mobile types we use, since I think mobile has the most complete version, as the endpoints are specifically designed for them. I think the only addition outside of mobile is innerContent on blocks, which I'm not sure are used anywhere anyway. 

Going to check the endpoints themselves later some time to confirm everything returned is within the types.